### PR TITLE
Adding traits for read, write and erase functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.33.0
+  - 1.35.0
   - stable
   - nightly
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spi-memory"
 version = "0.1.0"
-authors = ["Jonas Schievink <jonasschievink@gmail.com>"]
+authors = ["Jonas Schievink <jonasschievink@gmail.com>", "Henrik Böving <hargonix@gmail.com>"]
 edition = "2018"
 description = "A generic driver for different SPI Flash and EEPROM chips"
 documentation = "https://docs.rs/spi-memory/"

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -26,8 +26,8 @@ use stm32f4xx_hal::spi::Spi;
 use stm32f4xx_hal::stm32 as pac;
 use stm32f4xx_hal::time::{Bps, MegaHertz};
 
-use spi_memory::series25::Flash;
 use spi_memory::prelude::*;
+use spi_memory::series25::Flash;
 
 use core::fmt::Write as _;
 

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -15,18 +15,19 @@
 extern crate panic_semihosting;
 
 use cortex_m_rt::entry;
-use stm32f4xx_hal::spi::Spi;
-use stm32f4xx_hal::stm32 as pac;
-use stm32f4xx_hal::gpio::GpioExt;
-use stm32f4xx_hal::time::{Bps, MegaHertz};
-use stm32f4xx_hal::rcc::RccExt;
-use stm32f4xx_hal::serial::{self, Serial};
-use embedded_hal::spi::MODE_0;
+use cortex_m_semihosting::hprintln;
 use embedded_hal::digital::v2::OutputPin;
 use embedded_hal::serial::Write;
-use cortex_m_semihosting::hprintln;
+use embedded_hal::spi::MODE_0;
+use stm32f4xx_hal::gpio::GpioExt;
+use stm32f4xx_hal::rcc::RccExt;
+use stm32f4xx_hal::serial::{self, Serial};
+use stm32f4xx_hal::spi::Spi;
+use stm32f4xx_hal::stm32 as pac;
+use stm32f4xx_hal::time::{Bps, MegaHertz};
 
 use spi_memory::series25::Flash;
+use spi_memory::prelude::*;
 
 use core::fmt::Write as _;
 
@@ -39,8 +40,7 @@ const BAUDRATE: u32 = 912600;
 /// Size of the flash chip in bytes.
 const SIZE_IN_BYTES: u32 = (MEGABITS * 1024 * 1024) / 8;
 
-
-fn print<'a, E>(buf: &[u8], w: &'a mut (dyn Write<u8, Error=E> + 'static)) {
+fn print<'a, E>(buf: &[u8], w: &'a mut (dyn Write<u8, Error = E> + 'static)) {
     for c in buf {
         write!(w, "{:02X}", c).unwrap();
     }
@@ -55,7 +55,7 @@ fn main() -> ! {
 
     let cs = {
         let mut cs = gpioa.pa9.into_push_pull_output();
-        cs.set_high().unwrap();  // deselect
+        cs.set_high().unwrap(); // deselect
         cs
     };
 
@@ -64,7 +64,13 @@ fn main() -> ! {
         let miso = gpioa.pa6.into_alternate_af5();
         let mosi = gpioa.pa7.into_alternate_af5();
 
-        Spi::spi1(periph.SPI1, (sck, miso, mosi), MODE_0, MegaHertz(1).into(), clocks)
+        Spi::spi1(
+            periph.SPI1,
+            (sck, miso, mosi),
+            MODE_0,
+            MegaHertz(1).into(),
+            clocks,
+        )
     };
 
     let mut serial = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub trait Read<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     ///
     /// # Parameters
     /// * `addr`: The address to start reading at.
-    /// * `buf`: The buffer to read buf.len() bytes into.
+    /// * `buf`: The buffer to read `buf.len()` bytes into.
     fn read(&mut self, addr: Addr, buf: &mut [u8]) -> Result<(), Error<SPI, CS>>;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     ///
     /// # Parameters
     /// * `addr`: The address to start erasing at. If the address is not on a sector boundary,
-    /// the lower bits can be ignored in order to make it fit
+    ///   the lower bits can be ignored in order to make it fit.
     fn erase_sectors(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>>;
 
     /// Erases the memory chip fully.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,8 @@ pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     /// Erases sectors from the memory chip.
     ///
     /// # Parameters
-    /// * `addr`: The address to start erasing at.
+    /// * `addr`: The address to start erasing at. If the address is not on a sector boundary,
+    /// the lower bits can be ignored in order to make it fit
     fn erase_sectors(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>>;
 
     /// Erases the memory chip fully.
@@ -88,8 +89,7 @@ pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     /// it is writing to have already been erased and should not do any erasing themselves.
     ///
     /// # Parameters
-    /// * `addr`: The address to write to. If the address is not on a sector boundary,
-    /// the lower bits can be ignored in order to make it fit
+    /// * `addr`: The address to write to.
     /// * `data`: The bytes to write to `addr`.
     fn write_bytes(&mut self, addr: Addr, data: &mut [u8]) -> Result<(), Error<SPI, CS>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ pub mod prelude;
 pub mod series25;
 mod utils;
 
-use core::convert::TryInto;
 use core::fmt::{self, Debug};
 use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
@@ -35,10 +34,6 @@ pub enum Error<SPI: Transfer<u8>, GPIO: OutputPin> {
 
     /// A GPIO could not be set.
     Gpio(GPIO::Error),
-
-    /// The data or the address submitted for a write onto a Flash chip did not match its
-    /// sector length.
-    SectorLength,
 
     /// Status register contained unexpected flags.
     ///
@@ -61,7 +56,6 @@ where
             Error::Spi(spi) => write!(f, "Error::Spi({:?})", spi),
             Error::Gpio(gpio) => write!(f, "Error::Gpio({:?})", gpio),
             Error::UnexpectedStatus => f.write_str("Error::UnexpectedStatus"),
-            Error::SectorLength => f.write_str("Error::SectorLength"),
             Error::__NonExhaustive(_) => unreachable!(),
         }
     }
@@ -78,10 +72,7 @@ pub trait Read<Addr, SPI: Transfer<u8>, CS: OutputPin> {
 }
 
 /// A trait for writing and erasing operations on a memory chip.
-pub trait BlockDevice<Addr: TryInto<usize> + Copy, SPI: Transfer<u8>, CS: OutputPin>
-where
-    <Addr as core::convert::TryInto<usize>>::Error: core::fmt::Debug,
-{
+pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     /// Erases sectors from the memory chip.
     ///
     /// # Parameters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,9 @@ where
     fn erase_sectors(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>>;
 
     /// Erases the memory chip fully.
-    /// Warning: Full erase operations do take some time usually
+
+    /// Warning: Full erase operations can take a significant amount of time.
+    /// Check your device's datasheet for precise numbers.
     fn erase_all(&mut self) -> Result<(), Error<SPI, CS>>;
     /// Writes bytes onto the memory chip. This method is supposed to assume that the sectors
     /// it is writing to have already been erased and should not do any erasing themselves.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,14 @@
 
 #[macro_use]
 mod log;
+pub mod prelude;
 pub mod series25;
 mod utils;
 
+use core::convert::TryInto;
 use core::fmt::{self, Debug};
 use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
-use core::convert::TryInto;
 
 mod private {
     #[derive(Debug)]
@@ -35,7 +36,7 @@ pub enum Error<SPI: Transfer<u8>, GPIO: OutputPin> {
     /// A GPIO could not be set.
     Gpio(GPIO::Error),
 
-    /// The data or the address submitted for a write onto a Flash chip did not match its 
+    /// The data or the address submitted for a write onto a Flash chip did not match its
     /// sector length
     SectorLength,
 
@@ -77,9 +78,10 @@ pub trait Read<Addr, SPI: Transfer<u8>, CS: OutputPin> {
 }
 
 /// A trait for writing and erasing operations on a memory chip
-pub trait BlockDevice<Addr: TryInto<usize> + Copy, SPI: Transfer<u8>, CS: OutputPin> 
-    where <Addr as core::convert::TryInto<usize>>::Error : core::fmt::Debug,  
-    {
+pub trait BlockDevice<Addr: TryInto<usize> + Copy, SPI: Transfer<u8>, CS: OutputPin>
+where
+    <Addr as core::convert::TryInto<usize>>::Error: core::fmt::Debug,
+{
     /// The sector length in bytes, should be set to 1 for EEPROM implementations
     const SECTOR_LENGTH: usize;
 
@@ -92,18 +94,23 @@ pub trait BlockDevice<Addr: TryInto<usize> + Copy, SPI: Transfer<u8>, CS: Output
     /// * `addr`: The address to start erasing at
     /// * `amount`: The amount of bytes to erase, starting at `addr`
     fn erase_bytes(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>> {
-        if amount < Self::SECTOR_LENGTH || amount % Self::SECTOR_LENGTH != 0 || addr.try_into().unwrap() % Self::SECTOR_LENGTH != 0  {
+        if amount < Self::SECTOR_LENGTH
+            || amount % Self::SECTOR_LENGTH != 0
+            || addr.try_into().unwrap() % Self::SECTOR_LENGTH != 0
+        {
             return Err(Error::SectorLength);
         }
-        unsafe {
-            self.erase_bytes_unchecked(addr, amount)
-        }
+        unsafe { self.erase_bytes_unchecked(addr, amount) }
     }
 
     /// The "internal" method called by [erase_bytes](BlockDevice::erase_bytes), this function doesn't
     /// need to perform the checks regarding [SECTOR_LENGTH](BlockDevice::SECTOR_LENGTH) and is not supposed
     /// to be called by the end user of this library (which is the reason it is marked unsafe)
-    unsafe fn erase_bytes_unchecked(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>>;
+    unsafe fn erase_bytes_unchecked(
+        &mut self,
+        addr: Addr,
+        amount: usize,
+    ) -> Result<(), Error<SPI, CS>>;
 
     /// Erases the memory chip fully
     fn erase_all(&mut self) -> Result<(), Error<SPI, CS>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     fn erase_sectors(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>>;
 
     /// Erases the memory chip fully.
-
+    ///
     /// Warning: Full erase operations can take a significant amount of time.
     /// Check your device's datasheet for precise numbers.
     fn erase_all(&mut self) -> Result<(), Error<SPI, CS>>;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,2 @@
+//! Automatically loads in the BlockDevice and Read trait so the user doesn't have to do that all the time.
 pub use crate::{BlockDevice, Read};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,1 @@
+pub use crate::{BlockDevice, Read};

--- a/src/series25.rs
+++ b/src/series25.rs
@@ -1,8 +1,9 @@
 //! Driver for 25-series SPI Flash and EEPROM chips.
 
-use crate::{utils::HexSlice, Error};
+use crate::{utils::HexSlice, Error, Read, BlockDevice};
 use bitflags::bitflags;
 use core::fmt;
+use core::convert::TryInto;
 use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
 
@@ -50,8 +51,8 @@ enum Opcode {
 bitflags! {
     /// Status register bits.
     pub struct Status: u8 {
-        /// **W**rite **I**n **P**rogress bit.
-        const WIP = 1 << 0;
+        /// Erase or write in progress
+        const BUSY = 1 << 0;
         /// Status of the **W**rite **E**nable **L**atch.
         const WEL = 1 << 1;
         /// The 3 protection region bits.
@@ -90,7 +91,7 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
 
         // Here we don't expect any writes to be in progress, and the latch must
         // also be deasserted.
-        if !(status & (Status::WIP | Status::WEL)).is_empty() {
+        if !(status & (Status::BUSY | Status::WEL)).is_empty() {
             return Err(Error::UnexpectedStatus);
         }
 
@@ -124,10 +125,15 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
         Ok(Status::from_bits_truncate(buf[1]))
     }
 
+    fn write_enable(&mut self) -> Result<(), Error<SPI, CS>> {
+        let mut cmd_buf = [Opcode::WriteEnable as u8];
+        self.command(&mut cmd_buf)?;
+        Ok(())
+    }
+}
+
+impl<SPI: Transfer<u8>, CS: OutputPin> Read<u32, SPI, CS> for Flash<SPI, CS>{
     /// Reads flash contents into `buf`, starting at `addr`.
-    ///
-    /// This will always read `buf.len()` worth of bytes, filling up `buf`
-    /// completely.
     ///
     /// Note that `addr` is not fully decoded: Flash chips will typically only
     /// look at the lowest `N` bits needed to encode their size, which means
@@ -137,9 +143,9 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
     ///
     /// # Parameters
     ///
-    /// * **`addr`**: 24-bit address to start reading at.
-    /// * **`buf`**: Destination buffer to fill.
-    pub fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<(), Error<SPI, CS>> {
+    /// * `addr`: 24-bit address to start reading at.
+    /// * `buf`: Destination buffer to fill.
+    fn read(&mut self, addr: u32, buf: &mut [u8]) -> Result<(), Error<SPI, CS>> {
         // TODO what happens if `buf` is empty?
 
         let mut cmd_buf = [
@@ -156,5 +162,53 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
         }
         self.cs.set_high().map_err(Error::Gpio)?;
         spi_result.map(|_| ()).map_err(Error::Spi)
+    }
+}
+
+impl<SPI: Transfer<u8>, CS: OutputPin> BlockDevice<u32, SPI, CS> for Flash<SPI, CS> {
+    const SECTOR_LENGTH: usize = 4096;
+
+    unsafe fn erase_bytes_unchecked(&mut self, addr: u32, amount: usize) -> Result<(), Error<SPI, CS>> {
+        Ok(())
+    }
+
+    fn write_bytes(&mut self, addr: u32, data: &mut [u8]) -> Result<(), Error<SPI, CS>> {
+        let mut current_addr = addr;
+        for (c, chunk) in data.chunks_mut(256).enumerate() {
+            self.write_enable()?;
+
+            current_addr = (addr as usize + c * 256).try_into().unwrap();
+            let mut cmd_buf = [
+                Opcode::PageProg as u8,
+                (current_addr >> 16) as u8,
+                (current_addr >> 8) as u8,
+                current_addr as u8,
+            ];
+
+            self.cs.set_low().map_err(Error::Gpio)?;
+            let mut spi_result = self.spi.transfer(&mut cmd_buf);
+            if spi_result.is_ok() {
+                spi_result = self.spi.transfer(chunk);
+            }
+            self.cs.set_high().map_err(Error::Gpio)?;
+            spi_result.map(|_| ()).map_err(Error::Spi)?;
+        }
+        Ok(())
+    }
+
+    fn erase_all(&mut self) -> Result<(), Error<SPI, CS>> {
+        self.write_enable()?;
+        let mut cmd_buf = [Opcode::ChipErase as u8];
+        self.command(&mut cmd_buf)?;
+
+        let mut done = false;
+        // Wait until the erase is done
+        // TODO: maybe exchange this with a delay
+        while !done {
+            let status = self.read_status()?;
+            done = (status & Status::BUSY).is_empty();
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Addresses #3 
This PR adds:
- A Read and a BlockDevice trait for read write and erase operations on both EEPROM and Flash chips
- A prelude file to export these traits
- Formats the crate with cargo fmt
- Myself as a co author