### PR TITLE
Microchip 25LCxxx support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ categories = ["embedded"]
 readme = "README.md"
 license = "0BSD"
 
+[features]
+# Microchip 25LCxxx series chip extras
+25lc = []
+default = []
+
 # cargo-release configuration
 [package.metadata.release]
 tag-message = "{{version}}"

--- a/src/series25.rs
+++ b/src/series25.rs
@@ -125,7 +125,7 @@ bitflags! {
 pub struct Flash<SPI: Transfer<u8>, CS: OutputPin> {
     spi: SPI,
     cs: CS,
-    page_size: u16
+    page_size: usize
 }
 
 impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
@@ -150,7 +150,7 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
     /// * **`cs`**: The **C**hip-**S**elect Pin connected to the `\CS`/`\CE` pin
     ///   of the flash chip. Will be driven low when accessing the device.
     /// * **`page_size`**: Page size of the chip
-    pub fn init_with_page_size(spi: SPI, cs: CS, page_size: u16) -> Result<Self, Error<SPI, CS>> {
+    pub fn init_with_page_size(spi: SPI, cs: CS, page_size: usize) -> Result<Self, Error<SPI, CS>> {
         let mut this = Self { spi, cs, page_size };
         let status = this.read_status()?;
         info!("Flash::init: status = {:?}", status);

--- a/src/series25.rs
+++ b/src/series25.rs
@@ -220,7 +220,7 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
     #[cfg(feature = "25lc")]
     pub fn wake_up_and_get_manufacturer_id(&mut self) -> Result<u8, Error<SPI, CS>> {
         // <Instruction byte><Dummy address 3 bytes><Manufacturer ID byte>
-        let mut cmd_buf = [Opcode::ReadDeviceId as u8, 0, 0, 0];
+        let mut cmd_buf = [Opcode::ReadDeviceId as u8, 0, 0, 0, 0];
         self.command(&mut cmd_buf)?;
         Ok(cmd_buf[3])
     }

--- a/src/series25.rs
+++ b/src/series25.rs
@@ -1,8 +1,10 @@
 //! Driver for 25-series SPI Flash and EEPROM chips.
-
-use crate::{utils::HexSlice, BlockDevice, Error, Read};
+#[cfg(not(feature = "25lc"))]
+use crate::utils::HexSlice;
+use crate::{BlockDevice, Error, Read};
 use bitflags::bitflags;
 use core::convert::TryInto;
+#[cfg(not(feature = "25lc"))]
 use core::fmt;
 use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;


### PR DESCRIPTION
Hi
Support for the following devices:


| Model     | Datasheet                                                                                                       | Density (bits) | Page size (bytes) |
|-----------|-----------------------------------------------------------------------------------------------------------------|----------------|-------------------|
| 25LC080C  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 8k             | 16                |
| 25LC080D  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 8k             | 32                |
| 25LC160C  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 16k            | 16                |
| 25LC160D  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 16k            | 32                |
| 25LC320A  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 32k            | 32                |
| 25LC640A  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 64k            | 32                |
| 25LC128   | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 128k           | 64                |
| 25LC256   | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/25LC080C-080D-160C-160D-320A-640A-128-256-20002131D.pdf) | 256k           | 64                |
| 25LC512   | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/22065C.pdf)                                              | 512k           | 128               |
| 25LC1024  | [Link](http://ww1.microchip.com/downloads/en/DeviceDoc/22064D.pdf)                                              | 1024k          | 256               |


Notable changes:
 * Page size is variable
* JEDEC not supported
* Deep sleep and wake up opcode additions