### PR TITLE
Make BlockDevice depend on Write<u8> to remove mutable reference on write buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Implement `Display` for `Error`
+* Make BlockDevice depend on embedded_hal's Write<u8> and make write_bytes buffer reference non-mutable
 
 ## 0.2.0 - 2020-03-25
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 use core::fmt::{self, Debug, Display};
-use embedded_hal::blocking::spi::Transfer;
 use embedded_hal::digital::v2::OutputPin;
 
 mod private {
@@ -11,9 +10,9 @@ mod private {
 ///
 /// This can encapsulate an SPI or GPIO error, and adds its own protocol errors
 /// on top of that.
-pub enum Error<SPI: Transfer<u8>, GPIO: OutputPin> {
+pub enum Error<E, GPIO: OutputPin> {
     /// An SPI transfer failed.
-    Spi(SPI::Error),
+    Spi(E),
 
     /// A GPIO could not be set.
     Gpio(GPIO::Error),
@@ -29,9 +28,9 @@ pub enum Error<SPI: Transfer<u8>, GPIO: OutputPin> {
     __NonExhaustive(private::Private),
 }
 
-impl<SPI: Transfer<u8>, GPIO: OutputPin> Debug for Error<SPI, GPIO>
+impl<E, GPIO: OutputPin> Debug for Error<E, GPIO>
 where
-    SPI::Error: Debug,
+    E: Debug,
     GPIO::Error: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -44,9 +43,9 @@ where
     }
 }
 
-impl<SPI: Transfer<u8>, GPIO: OutputPin> Display for Error<SPI, GPIO>
+impl<E, GPIO: OutputPin> Display for Error<E, GPIO>
 where
-    SPI::Error: Display,
+    E: Display,
     GPIO::Error: Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod utils;
 
 pub use crate::error::Error;
 
-use embedded_hal::blocking::spi::Transfer;
+use embedded_hal::blocking::spi::{Transfer, Write};
 use embedded_hal::digital::v2::OutputPin;
 
 /// A trait for reading operations from a memory chip.
@@ -31,23 +31,31 @@ pub trait Read<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     /// # Parameters
     /// * `addr`: The address to start reading at.
     /// * `buf`: The buffer to read `buf.len()` bytes into.
-    fn read(&mut self, addr: Addr, buf: &mut [u8]) -> Result<(), Error<SPI, CS>>;
+    fn read(&mut self, addr: Addr, buf: &mut [u8]) -> Result<(), Error<SPI::Error, CS>>;
 }
 
 /// A trait for writing and erasing operations on a memory chip.
-pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
+pub trait BlockDevice<
+    Addr,
+    SPI: Transfer<u8, Error = Self::SpiError> + Write<u8, Error = Self::SpiError>,
+    CS: OutputPin,
+>
+{
+    type SpiError;
+
     /// Erases sectors from the memory chip.
     ///
     /// # Parameters
     /// * `addr`: The address to start erasing at. If the address is not on a sector boundary,
     ///   the lower bits can be ignored in order to make it fit.
-    fn erase_sectors(&mut self, addr: Addr, amount: usize) -> Result<(), Error<SPI, CS>>;
+    fn erase_sectors(&mut self, addr: Addr, amount: usize)
+        -> Result<(), Error<Self::SpiError, CS>>;
 
     /// Erases the memory chip fully.
     ///
     /// Warning: Full erase operations can take a significant amount of time.
     /// Check your device's datasheet for precise numbers.
-    fn erase_all(&mut self) -> Result<(), Error<SPI, CS>>;
+    fn erase_all(&mut self) -> Result<(), Error<Self::SpiError, CS>>;
 
     /// Writes bytes onto the memory chip. This method is supposed to assume that the sectors
     /// it is writing to have already been erased and should not do any erasing themselves.
@@ -55,5 +63,5 @@ pub trait BlockDevice<Addr, SPI: Transfer<u8>, CS: OutputPin> {
     /// # Parameters
     /// * `addr`: The address to write to.
     /// * `data`: The bytes to write to `addr`.
-    fn write_bytes(&mut self, addr: Addr, data: &mut [u8]) -> Result<(), Error<SPI, CS>>;
+    fn write_bytes(&mut self, addr: Addr, data: &[u8]) -> Result<(), Error<Self::SpiError, CS>>;
 }


### PR DESCRIPTION
Hi!

I ran into the issue of write_bytes taking a &mut [u8], because the Transfer<u8> trait requires it.
The nRF52-hal SPI drivers appear to implement Write<_> at least, so I made the BlockDevice trait depend on that so write_bytes can be non-mutable.

This required some reorganisation of the Error type to receive the SPI Error type, as both Transfer and Write have their own associated Error type.

I might've missed some implications of depending on the Write trait, as I assumed that anything that implements Transfer, should have no problem implementing Write.
