### PR TITLE
Make `command` public to allow usage of custom commands

### DIFF
--- a/src/series25.rs
+++ b/src/series25.rs
@@ -141,7 +141,7 @@ impl<SPI: Transfer<u8>, CS: OutputPin> Flash<SPI, CS> {
         Ok(this)
     }
 
-    fn command(&mut self, bytes: &mut [u8]) -> Result<(), Error<SPI, CS>> {
+    pub fn command(&mut self, bytes: &mut [u8]) -> Result<(), Error<SPI, CS>> {
         // If the SPI transfer fails, make sure to disable CS anyways
         self.cs.set_low().map_err(Error::Gpio)?;
         let spi_result = self.spi.transfer(bytes).map_err(Error::Spi);


### PR DESCRIPTION
Many flash chips implement custom extensions, for example the
GD25Q16CSIG with a 128 bit unique id or Window 25Q32JVSIQ with a 64 bit
unique id.

Without this change applications would need to reconstruct `SPI` after
dropping `Flash` or only execute custom commands before constructing
`Flash`, both rather ... unideal solutions.